### PR TITLE
Ruby 1.9 fixes

### DIFF
--- a/lib/simple_enum/version.rb
+++ b/lib/simple_enum/version.rb
@@ -1,5 +1,5 @@
 module SimpleEnum
 
   # +SimpleEnum+ version string.
-  VERSION = "1.4.0".freeze
+  VERSION = "1.4.0"
 end

--- a/test/object_support_test.rb
+++ b/test/object_support_test.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../test_helper', __FILE__)
+
 class ObjectSupportTest < ActiveSupport::TestCase
   
   test "ensure that symbols stay symbols" do


### PR DESCRIPTION
Specs didn't run with newest ruby 1.9.2, also without the fix in version.rb file gem didn't even install in newest ruby 1.9.2.
