### PR TITLE
Fix enum definitions

### DIFF
--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -45,8 +45,7 @@ module SimpleEnum
     end
 
     def included(base) #:nodoc:
-      base.send :class_attribute, :enum_definitions, :instance_writer => false, :instance_reader => false
-      base.enum_definitions = {}
+      base.send :class_attribute, :simple_enum_definitions, :instance_writer => false, :instance_reader => false
       base.send :extend, ClassMethods
     end
   end
@@ -166,7 +165,6 @@ module SimpleEnum
       values_inverted = values.invert
 
       # store info away
-      self.enum_definitions = {} if self.enum_definitions.nil?
       self.enum_definitions[enum_cd] = self.enum_definitions[options[:column]] = { :name => enum_cd, :column => options[:column], :options => options }
 
       # raise error if enum_cd == column
@@ -272,6 +270,10 @@ module SimpleEnum
 
       options.reverse_merge! :count => 1, :default => defaults
       I18n.translate(defaults.shift, options)
+    end
+
+    def enum_definitions
+      self.simple_enum_definitions ||= {}
     end
   end
 end

--- a/lib/simple_enum/mongoid.rb
+++ b/lib/simple_enum/mongoid.rb
@@ -27,8 +27,7 @@ module SimpleEnum
 
     included do
       # create class level methods
-      class_attribute :enum_definitions, :instance_writer => false, :instance_reader => false
-      enum_definitions = {}
+      class_attribute :simple_enum_definitions, :instance_writer => false, :instance_reader => false
     end
 
     module ClassMethods

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -14,6 +14,10 @@ class SimpleEnumTest < MiniTest::Unit::TestCase
     assert_raises(NoMethodError) { Dummy.new.enum_definitions= {} }
   end
 
+  def test_enum_definitions_local_to_model
+    assert_equal nil, Computer.enum_definitions[:gender]
+  end
+
   def test_getting_the_correct_integer_values_when_setting_to_symbol
     d = Dummy.new
     d.gender = :male


### PR DESCRIPTION
This fixes two bugs. The second one is that `enum_definitions` returned the same object for all classes.

Tests included.

Please let me know when you release a version with these fixes. Thanks!
