### PR TITLE
Removed read_attributes and write_attributes in favor of send

### DIFF
--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -176,7 +176,7 @@ module SimpleEnum
 
       # generate getter
       define_method("#{enum_cd}") do
-        id = respond_to?(:read_attribute) ? read_attribute(options[:column]) : send(options[:column])
+        id = send(options[:column])
         values_inverted[id]
       end
 
@@ -185,7 +185,7 @@ module SimpleEnum
         real = new_value.blank? ? nil : values[EnumHash.symbolize(new_value)]
         real = new_value if real.nil? && values_inverted[new_value].present?
         raise(ArgumentError, "Invalid enumeration value: #{new_value}") if (options[:whiny] and real.nil? and !new_value.blank?)
-        respond_to?(:write_attribute) ? write_attribute(options[:column], real) : send("#{options[:column]}=", real)
+        send("#{options[:column]}=", real)
       end
 
       # generate checker
@@ -244,11 +244,11 @@ module SimpleEnum
           sym = EnumHash.symbolize(k)
 
           define_method("#{prefix}#{sym}?") do
-            current = respond_to?(:read_attribute) ? read_attribute(options[:column]) : send(options[:column])
+            current = send(options[:column])
             code == current
           end
           define_method("#{prefix}#{sym}!") do
-            respond_to?(:write_attribute) ? write_attribute(options[:column], code) : send("#{options[:column]}=", code)
+            send("#{options[:column]}=", code)
             sym
           end
 


### PR DESCRIPTION
The model of `respond_to?(:read_attribute)` does not work with ActiveRecord classes that define their `enum_cd` as a `attr_accessor`.

I have such a case where I want the enum to be there for view-validation and i18n, but I serialize the results manually to the database. Due to `read_attribute` being present simple_enum is trying to call `read_attribute` on a field that's not managed by ActiveRecord.

``` ruby
class Command < ActiveRecord::Base
  attr_accessor :result_cd
  as_enum :result, [:a, :b, :c]
end

c = Command.new
c.result = :a 
c.a? # => false
```

After looking through the code I noticed that there is already a switch for Mongoid that uses send instead of read_attribute and all tests still pass with AR 3.2

Is there some reason read_attribute and write_attribute is still used instead of the setters/getters?
