### PR TITLE
Added singleton alias for find_by from the enumeration name to the column

### DIFF
--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -216,12 +216,8 @@ module SimpleEnum
       end
 
       # generate find_by enum singleton
-      (class << self; self end).define_method("find_by_#{enum_cd}") do |*args|
+      (class << self; self end).send(:define_method, "find_by_#{enum_cd}") do |*args|
         send("find_by_#{options[:column]}", args)
-      end
-
-      (class << self; self end).define_method("find_all_by_#{enum_cd}") do |*args|
-        send("find_all_by_#{options[:column]}", args)
       end
 
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)


### PR DESCRIPTION
Creates a singleton method for find_by_&lt;enum name&gt; as an alias to find_by_&lt;column name&gt;
