### PR TITLE
Update error messages to match ActiveModel formatting.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,8 +3,8 @@ en:
   activerecord:
     errors:
       messages:
-        invalid_enum: invalid option supplied.
-  mongoid:   
+        invalid_enum: invalid option supplied
+  mongoid:
     errors:
       messages:
-        invalid_enum: invalid option supplied.
+        invalid_enum: invalid option supplied

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -188,7 +188,7 @@ class SimpleEnumTest < MiniTest::Unit::TestCase
 
     computer = validated_comp.new
     assert !computer.save, "save should return false"
-    assert_equal "invalid option supplied.", computer.errors[:manufacturer].first
+    assert_equal "invalid option supplied", computer.errors[:manufacturer].first
     assert_equal "y u no os?", computer.errors[:operating_system].first
   end
 


### PR DESCRIPTION
Hi there!  First, thanks for the awesome gem, it's great.  There hasn't been a good enum gem for some time, but this seems to have all the bells and whistles.

I wanted to submit this pull request to adjust the formatting of the default error messages to better match [ActiveModel](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/locale/en.yml) & [ActiveRecord](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/locale/en.yml) error messages.  If you look at the `en.errors.messages` path of both those locale files I linked to, you can see that none of the messages end with a period.  This is because sometimes those strings will be concatenated (via `to_sentence` or similar) if there are multiple errors in a field.  The current formatting used by simple_enum causes a period to appear in the middle of a sentence or comma-separate list of errors pertaining to a field.

I know this can be fixed by supplying a custom locale value in a local project, but I figured that with this being a gem based on ActiveModel, it should probably follow the same use cases of ActiveModel itself.  Thanks for the consideration!
