### PR TITLE
Add documentation for `as_enum` `:strings` option to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -82,6 +82,13 @@ useful when creating queries, displaying option elements or similar:
   *Disclaimer*: if you _ever_ decide to reorder this array, beaware that any previous mapping is lost. So it's recommended
   to create mappings (that might change) using hashes instead of arrays. For stuff like gender it might be probably perfectly
   fine to use arrays though.
+* You can use string values instead of integer values if your database column has the type +string+ or +text+:
+
+       class User < ActiveRecord::Base
+         as_eum :status, [:deleted, :active, :dsiabled], :strings => true
+       end
+
+       User.create!(status: :active) #=> #<User id: 1, status_cd: "active">
 * Want to use `SimpleEnum` in an ActiveModel, or other class, just do:
 
         class MyModel


### PR DESCRIPTION
I noticed that the `strings` option for `as_enum` wasn't mentioned in the README (I only found it myself while browsing the code :) ), thought it was worth adding.

Additionally, I can't seem to find a reference to `strings` in the the PR for 2.0 (https://github.com/lwe/simple_enum/pull/36), it looks like this feature is still supported, has the name of the option changed, or is it inferred?
