### PR TITLE
Change `validates_as_enum` to allow symbol values for string enums

### DIFF
--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -182,6 +182,7 @@ module SimpleEnum
 
       # generate setter
       define_method("#{enum_cd}=") do |new_value|
+        new_value = new_value.to_s if options[:strings] and new_value
         real = new_value.blank? ? nil : values[EnumHash.symbolize(new_value)]
         real = new_value if real.nil? && values_inverted[new_value].present?
         raise(ArgumentError, "Invalid enumeration value: #{new_value}") if (options[:whiny] and real.nil? and !new_value.blank?)

--- a/lib/simple_enum/validation.rb
+++ b/lib/simple_enum/validation.rb
@@ -18,6 +18,8 @@ module ActiveModel
           enum_def = @klass.enum_definitions[attribute]
           raw_value = record.send(enum_def[:column])
 
+          raw_value = raw_value.to_s if enum_def[:options][:strings] && raw_value
+
           next if (raw_value.nil? && options[:allow_nil]) || (raw_value.blank? && options[:allow_blank])
 
           unless @klass.send(enum_def[:name].to_s.pluralize).values.include?(raw_value)

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -30,6 +30,8 @@ def reload_db(options = {})
     t.column :word_cd, :string, :limit => 5
     t.column :role_cd, :string
     t.column :other, :integer
+    t.column :numeric_cd, :string
+    t.column :nilish_cd, :string
   end
 
   # Create ref-data table and fill with records
@@ -65,6 +67,16 @@ def extend_computer(current_i18n_name = "Computer", &block)
   end
 end
 
+def extend_dummy(current_i18n_name = "Dummy", &block)
+  Class.new(Dummy) do
+    ar32? ? self.table_name = 'dummies' : set_table_name('dummies')
+    instance_eval &block
+    instance_eval <<-RUBY
+      def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
+    RUBY
+  end
+end
+
 def named_dummy(class_name, &block)
   begin
     return class_name.constantize
@@ -83,6 +95,8 @@ class Dummy < ActiveRecord::Base
   as_enum :word, { :alpha => 'alpha', :beta => 'beta', :gamma => 'gamma'}
   as_enum :didum, [ :foo, :bar, :foobar ], :column => 'other'
   as_enum :role, [:admin, :member, :anon], :strings => true
+  as_enum :numeric, [:"100", :"3.14"], :strings => true
+  as_enum :nilish, [:nil], :strings => true
 end
 
 class Gender < ActiveRecord::Base

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -46,6 +46,16 @@ def extend_computer(current_i18n_name = "Computer", &block)
   end
 end
 
+def extend_dummy(current_i18n_name = "Dummy", &block)
+  Class.new(Dummy) do
+    self.collection_name = 'dummies'
+    instance_eval &block
+    instance_eval <<-RUBY
+      def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
+    RUBY
+  end
+end
+
 def named_dummy(class_name, &block)
   begin
     return class_name.constantize
@@ -72,6 +82,8 @@ class Dummy
   as_enum :word, { :alpha => 'alpha', :beta => 'beta', :gamma => 'gamma'}
   as_enum :didum, [ :foo, :bar, :foobar ], :column => 'other'
   as_enum :role, [:admin, :member, :anon], :strings => true
+  as_enum :numeric, [:"100", :"3.14"], :strings => true
+  as_enum :nilish, [:nil], :strings => true
 
   before_save :check_typed
 

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -44,6 +44,23 @@ class SimpleEnumTest < MiniTest::Unit::TestCase
     assert_equal(1, d.gender_cd)
   end
 
+  def test_setting_value_when_it_is_not_a_string_and_strings_is_true
+    d = Dummy.new    
+    d.numeric = 100
+    assert_equal(:"100", d.numeric)
+    assert_equal("100", d.numeric_cd)
+    d.numeric = 3.14
+    assert_equal(:"3.14", d.numeric)
+    assert_equal("3.14", d.numeric_cd)
+  end
+
+  def test_setting_value_to_nil_when_enum_has_nil_as_symbol_and_strings_is_true
+    d = Dummy.new
+    d.nilish = nil
+    assert_equal(nil, d.nilish)
+    assert_equal(nil, d.nilish_cd)
+  end
+
   def test_setting_value_as_key_in_constructor
     d = Dummy.new :gender => 1
     assert_equal(:female, d.gender)
@@ -219,6 +236,15 @@ class SimpleEnumTest < MiniTest::Unit::TestCase
     computer.manufacturer_cd = 0
     computer.operating_system_cd = 0
     assert_equal(true, computer.save)
+  end
+
+  def test_validator_allows_symbols_as_raw_colum_value_if_strings_is_true
+    validated_dummy = extend_dummy do
+      validates_as_enum :role
+    end
+
+    d = validated_dummy.new :role_cd  => :admin
+    assert d.valid?, "valid? should return true"
   end
 
   def test_that_argumenterror_is_raised_if_invalid_symbol_is_passed


### PR DESCRIPTION
Imagine we have the following model:

```
class User < ActiveRecord::Base
  as_eum :status, [:deleted, :active, :dsiabled], :strings => true
  validates_as_enum :status
end
```

If you use `User.find_or_create_by` you must use the underlying column name (`status_cd` by default in this case). This means that `status_cd` gets set directly, and not through `status=` so if you pass a symbol it does not get coerced to a string. ActiveRecord can do this coercion, but `validates_as_enum` expects the value of `status_cd` to be a string (one of `['deleted', 'active', 'disabled']` in this case).

So, this happens:

```
User.find_or_create_by(status_cd: :active) #=> ActiveRecord::RecordInvalid
User.find_or_create_by(status_cd: 'active') #=> #<User id:1, status_cd: "active">
```

This changes the validator to allow the column value to be a symbol iff the `strings` option is being used, which means you can do:

```
User.find_or_create_by(status_cd: :active) #=> #<User id:1, status_cd: "active">
```
