### PR TITLE
use #send() to not raise error #70

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ pkg
 .*.sw?
 tmp
 Gemfile.lock
+gemfiles/*.lock
 :memory*

--- a/lib/simple_enum/accessors/accessor.rb
+++ b/lib/simple_enum/accessors/accessor.rb
@@ -29,11 +29,11 @@ module SimpleEnum
       end
 
       def changed?(object)
-        object.attribute_changed?(source)
+        object.send(:attribute_changed?, source)
       end
 
       def was(object)
-        enum.key(object.attribute_was(source))
+        enum.key(object.send(:attribute_was, source))
       end
 
       def to_s

--- a/spec/simple_enum/accessors_spec.rb
+++ b/spec/simple_enum/accessors_spec.rb
@@ -159,6 +159,20 @@ describe SimpleEnum::Accessors do
         expect(object).to receive(:attribute_was).with('gender_cd') { 1 }
         expect(subject.was(object)).to eq :female
       end
+
+    end
+  end
+
+  context 'dirty attributes on ActiveModel', active_record: true do
+    fake_active_record(:klass) { as_enum :gender, %w{male female} }
+    let(:object) { klass.create(gender: :male) }
+
+    it 'does not raise error "private method attribute_was called"' do
+      object.gender = :female
+      expect do
+        expect(object.gender_changed?).to be_true
+        expect(object.gender_was).to eq :male
+      end.to_not raise_error
     end
   end
 


### PR DESCRIPTION
In Rails 4.0.x the AM::Dirty methods are private, thus the error

> private method `attribute_was' called

is raised when using #was or #changed? on the accessor. Fixed this
by making use uf #send to call the private methods. Starting with
4.1 these methods are public.

see #70
