### PR TITLE
Add 'persistence_method' option that is called when an attribute is written to

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jane.gender    # => :female
 jane.gender_cd # => 1
 ```
 
-Easily switch to another value using the bang methods, this does not save
+Easily switch to another value using the bang methods. By default, this does not save
 the record, only switch the value.
 
 ```ruby
@@ -92,6 +92,20 @@ joe.male!     # => :male
 joe.gender    # => :male
 joe.gender_cd # => 0
 ```
+
+To change the behavior so that a method is called to save the value (e.g. in case of ActiveRecord
+this would be `save` or `save!`):
+
+In `config/initializers/simple_enum.rb` add:
+
+`SimpleEnum.persistence_method = "save!"`
+
+```
+joe = User.new
+joe.male!         # => :male
+User.last.male?   # => true
+```
+
 
 Accessing actual enum values is possible at the class level:
 

--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -33,6 +33,9 @@ module SimpleEnum
   mattr_accessor :field
   @@field = {}
 
+  mattr_accessor :persistence_method
+  @@persistence_method = nil
+
   def self.configure
     yield(self)
   end

--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -61,7 +61,13 @@ module SimpleEnum
       simple_enum_module.module_eval do
         enum.each_pair do |key, value|
           define_method("#{accessor.prefix}#{key}?") { accessor.selected?(self, key) }
-          define_method("#{accessor.prefix}#{key}!") { accessor.write(self, key) }
+          define_method("#{accessor.prefix}#{key}!") {
+            result = accessor.write(self, key)
+            if SimpleEnum.persistence_method
+              self.send(SimpleEnum.persistence_method)
+            end
+            result
+          }
         end
       end
     end

--- a/spec/simple_enum/accessors_spec.rb
+++ b/spec/simple_enum/accessors_spec.rb
@@ -113,6 +113,7 @@ describe SimpleEnum::Accessors do
           expect(subject.write(object, :other)).to be_nil
           expect(object.gender_cd).to be_nil
         end
+
       end
 
       it_behaves_like 'writing an enum'

--- a/spec/simple_enum/attribute_spec.rb
+++ b/spec/simple_enum/attribute_spec.rb
@@ -121,6 +121,14 @@ describe SimpleEnum::Attribute do
         expect(accessor).to receive(:write).with(subject, 'female') { 1 }
         expect(subject.female!).to eq 1
       end
+
+      it 'calls the persistence_method if specified' do
+        SimpleEnum.persistence_method = "some_method"
+        subject.stub(SimpleEnum.persistence_method)
+        expect(subject).to receive(SimpleEnum.persistence_method)
+        subject.female!
+        SimpleEnum.persistence_method = nil
+      end
     end
 
     context 'with a prefix' do


### PR DESCRIPTION
This is useful when using an ORM like ActiveRecord where it is desirable to
set the enum value without having to additionally call `#save!()` after setting
the enum field's value via the `!` accessor writer method.

Usage:

Set the option to the desired method to be called when an attribute is written to:

`SimpleEnum.persistence_method = "save!"`
