### PR TITLE
Suggest "genders_for_select" for generating select options.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -192,9 +192,13 @@ useful when creating queries, displaying option elements or similar:
 
 * To make it easier to create dropdowns with values use:
 
-        <%= select(:user, :gender, User.genders.keys) %>
+        <%= select(:user, :gender, User.genders_for_select) %>
+        
+  This creates a `select` with options nicely formatted:
+        
+        [ [ "Male", 0 ], [ "Female", 1 ] ]
 
-* Need translated keys et al in your forms? SimpleEnum provides a <tt><enum>_for_select</tt> method:
+* Need *translated* keys et al in your forms? SimpleEnum provides a <tt><enum>_for_select</tt> method:
 
        # on the gender field
        <%= select("user", "gender", User.genders_for_select) %>


### PR DESCRIPTION
On my first read of this it suggested using `User.genders.keys` for a select, which isn't really the best option for a `select` since you need both the internal database value (either the Integer or String) **and** the **formatted** display value.

I changed my code to use the most excellent `User.genders_for_select` and it does exactly as you'd expect.
