### PR TITLE
Development for v3

### DIFF
--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -77,7 +77,7 @@ module SimpleEnum
       return unless respond_to?(:scope)
 
       enum.each_pair do |key, value|
-        scope "#{accessor.prefix}#{key.pluralize}", -> { accessor.scope(self, value) }
+        scope "#{accessor.prefix}#{key.to_s.pluralize}", -> { accessor.scope(self, value) }
       end
     end
   end

--- a/lib/simple_enum/enum.rb
+++ b/lib/simple_enum/enum.rb
@@ -1,12 +1,14 @@
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/hash'
 
 module SimpleEnum
   class Enum
-    attr_reader :name, :hash
+    attr_reader :name
 
     def initialize(name, hash)
       @name = name.to_s
       @hash = hash
+      @symbols_hash = hash.symbolize_keys
     end
 
     def include?(key)
@@ -26,16 +28,16 @@ module SimpleEnum
     alias_method :[], :value
 
     def each_pair(&block)
-      hash.each_pair(&block)
+      symbols_hash.each_pair(&block)
     end
     alias_method :each, :each_pair
 
     def map(&block)
-      hash.map(&block)
+      symbols_hash.map(&block)
     end
 
     def keys
-      hash.keys
+      symbols_hash.keys
     end
 
     def values_at(*keys)
@@ -46,5 +48,9 @@ module SimpleEnum
     def to_s
       name
     end
+
+    # Private access to hash and symbolized hash
+    private
+    attr_reader :hash, :symbols_hash
   end
 end

--- a/lib/simple_enum/version.rb
+++ b/lib/simple_enum/version.rb
@@ -1,5 +1,5 @@
 module SimpleEnum
 
   # The current `SimpleEnum` version.
-  VERSION = "2.1.1"
+  VERSION = "3.0.0.dev"
 end

--- a/lib/simple_enum/view_helpers.rb
+++ b/lib/simple_enum/view_helpers.rb
@@ -23,6 +23,7 @@ module SimpleEnum
       record = record.class unless record.respond_to?(reader)
 
       record.send(reader).map { |key, value|
+        key = key.to_s
         name = record.human_enum_name(enum, key) if record.respond_to?(:human_enum_name)
         name ||= translate_enum_key(enum, key)
         [name, encode_as_value ? value : key]

--- a/simple_enum.gemspec
+++ b/simple_enum.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = "Simple enum-like field support for models."
   s.description = "Provides enum-like fields for ActiveRecord, ActiveModel and Mongoid models."
 
-  s.required_ruby_version     = ">= 1.9.3"
+  s.required_ruby_version     = ">= 2.0.0"
   s.required_rubygems_version = ">= 2.0.0"
 
   s.authors  = ["Lukas Westermann"]

--- a/spec/simple_enum/attribute_spec.rb
+++ b/spec/simple_enum/attribute_spec.rb
@@ -134,22 +134,22 @@ describe SimpleEnum::Attribute do
       end
 
       it 'delegates #male? to accessor' do
-        expect(accessor).to receive(:selected?).with(subject, 'male') { true }
+        expect(accessor).to receive(:selected?).with(subject, :male) { true }
         expect(subject.male?).to be_truthy
       end
 
       it 'delegates #female? to accessor' do
-        expect(accessor).to receive(:selected?).with(subject, 'female') { false }
+        expect(accessor).to receive(:selected?).with(subject, :female) { false }
         expect(subject.female?).to be_falsey
       end
 
       it 'delegates #male! to accessor' do
-        expect(accessor).to receive(:write).with(subject, 'male') { 0 }
+        expect(accessor).to receive(:write).with(subject, :male) { 0 }
         expect(subject.male!).to eq 0
       end
 
       it 'delegates #female! to accessor' do
-        expect(accessor).to receive(:write).with(subject, 'female') { 1 }
+        expect(accessor).to receive(:write).with(subject, :female) { 1 }
         expect(subject.female!).to eq 1
       end
     end
@@ -164,22 +164,22 @@ describe SimpleEnum::Attribute do
       end
 
       it 'delegates #gender_male? to accessor' do
-        expect(accessor).to receive(:selected?).with(subject, 'male') { true }
+        expect(accessor).to receive(:selected?).with(subject, :male) { true }
         expect(subject.gender_male?).to be_truthy
       end
 
       it 'delegates #gender_female? to accessor' do
-        expect(accessor).to receive(:selected?).with(subject, 'female') { false }
+        expect(accessor).to receive(:selected?).with(subject, :female) { false }
         expect(subject.gender_female?).to be_falsey
       end
 
       it 'delegates #gender_male! to accessor' do
-        expect(accessor).to receive(:write).with(subject, 'male') { 0 }
+        expect(accessor).to receive(:write).with(subject, :male) { 0 }
         expect(subject.gender_male!).to eq 0
       end
 
       it 'delegates #gender_female! to accessor' do
-        expect(accessor).to receive(:write).with(subject, 'female') { 1 }
+        expect(accessor).to receive(:write).with(subject, :female) { 1 }
         expect(subject.gender_female!).to eq 1
       end
     end

--- a/spec/simple_enum/enum_spec.rb
+++ b/spec/simple_enum/enum_spec.rb
@@ -22,29 +22,23 @@ describe SimpleEnum::Enum do
     end
   end
 
-  context '#hash' do
-    subject { described_class.new(:gender, hash).hash }
-
-    it 'returns hash that was set in the constructor' do
-      expect(subject).to be_a(Hash)
-      expect(subject.keys).to eq %w{male female}
-      expect(subject.values).to eq [0, 1]
-    end
-  end
-
   context '#keys' do
     it 'returns the keys in the order added' do
-      expect(subject.keys).to eq %w{male female}
+      expect(subject.keys).to eq [:male, :female]
     end
   end
 
   context '#each_pair (aliased to #each)' do
     it 'yields twice with #each_pair' do
-      expect { |b| subject.each_pair(&b) }.to yield_control.exactly(2).times
+      result = []
+      subject.each_pair { |b| result << b }
+      expect(result).to eq [[:male, 0], [:female, 1]]
     end
 
     it 'yields twice with #each' do
-      expect { |b| subject.each(&b) }.to yield_control.exactly(2).times
+      result = []
+      subject.each { |b| result << b }
+      expect(result).to eq [[:male, 0], [:female, 1]]
     end
   end
 


### PR DESCRIPTION
- [x] Enums should be symbols, see #100
- [ ] #fetch method for SE::Enum, see #96 

Any other wishes? Also feel free to try this branch and see if it fixes #100 as expected.

This is a new major version, because the change to return symbols is a breaking change.

/cc @lucke84, @matthewrudy