### PR TITLE
Read #changed_attributes instead of _was #109

### DIFF
--- a/lib/simple_enum/accessors/accessor.rb
+++ b/lib/simple_enum/accessors/accessor.rb
@@ -33,7 +33,9 @@ module SimpleEnum
       end
 
       def was(object)
-        enum.key(object.send(:attribute_was, source))
+        changes = object.send(:changed_attributes)
+        key = changes.fetch(source, read_before_type_cast(object))
+        enum.key(key) if key
       end
 
       def scope(relation, value)

--- a/simple_enum.gemspec
+++ b/simple_enum.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '>= 10.1.0'
   s.add_development_dependency 'activerecord', '>= 4.0.0'
-  s.add_development_dependency 'mongoid', '>= 4.0.0.beta1'
+  s.add_development_dependency 'mongoid', '>= 4.0.0'
   s.add_development_dependency 'rspec', '~> 2.14'
 end


### PR DESCRIPTION
When `as_enum :column, ..., source: :column` is used, then #attribute_was was not returning the correct value.

Previously simple_enum delegated directly to #attribute_was method, internally Rails redirects to __send__(attr) if the attribute was not changed and so it returned the symbolized value, e.g. :female.

The current version now delegates directly to #changed_attributes.fetch

Fixes #109 