### PR TITLE
Add SimpleEnum::Enum#values

### DIFF
--- a/lib/simple_enum/enum.rb
+++ b/lib/simple_enum/enum.rb
@@ -42,6 +42,10 @@ module SimpleEnum
       hash.keys
     end
 
+    def values
+      hash.values
+    end
+
     def values_at(*keys)
       keys = keys.map(&:to_s)
       hash.values_at(*keys)

--- a/spec/simple_enum/enum_spec.rb
+++ b/spec/simple_enum/enum_spec.rb
@@ -38,6 +38,12 @@ describe SimpleEnum::Enum do
     end
   end
 
+  context '#values' do
+    it 'returns the values in the order added' do
+      expect(subject.values).to eq [0, 1]
+    end
+  end
+
   context '#each_pair (aliased to #each)' do
     it 'yields twice with #each_pair' do
       expect { |b| subject.each_pair(&b) }.to yield_control.exactly(2).times


### PR DESCRIPTION
Adding `SimpleEnum::Enum#values` method that simply returns `#values` of underlying `hash`. 

This'll help us migrating from legacy `simple_enum` to the latest. 
