### PR TITLE
Add VALID_OPTION_KEYS to SE::Attribute

### DIFF
--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -16,8 +16,10 @@ module SimpleEnum
     # Registered registrator methods from extensions
     EXTENSIONS = []
 
+    VALID_OPTION_KEYS = [:source, :prefix, :with, :accessor, :map]
+
     def as_enum(name, values, options = {})
-      options.assert_valid_keys(:source, :prefix, :with, :accessor, :map)
+      options.assert_valid_keys(*VALID_OPTION_KEYS)
 
       hash     = SimpleEnum::Hasher.map(values, options)
       enum     = SimpleEnum::Enum.new(name, hash)
@@ -31,7 +33,7 @@ module SimpleEnum
       end
 
       EXTENSIONS.uniq.each do |extension|
-        send "generate_enum_#{extension}_extension_for", enum, accessor
+        send "generate_enum_#{extension}_extension_for", enum, accessor, options
       end
 
       enum

--- a/lib/simple_enum/mongoid.rb
+++ b/lib/simple_enum/mongoid.rb
@@ -26,22 +26,20 @@ module SimpleEnum
     def self.included(base)
       base.extend SimpleEnum::Attribute
       base.extend SimpleEnum::Translation
-      base.extend SimpleEnum::Mongoid::ClassMethods
     end
 
-    module ClassMethods
+    module Extension
       # Wrap method chain to create mongoid field and additional
       # column options
-      def as_enum(name, values, options = {})
-        source = options[:source].to_s.presence || "#{name}#{SimpleEnum.suffix}"
+      def generate_enum_mongoid_extension_for(enum, accessor, options)
         field_options = options.delete(:field)
-        unless field_options === false
-          field_options ||= SimpleEnum.field
-          field(source, field_options) if field_options
-        end
-
-        super
+        return if field_options === false
+        field_options ||= SimpleEnum.field
+        field(accessor.source, field_options) if field_options
       end
     end
   end
 end
+
+SimpleEnum::Attribute::VALID_OPTION_KEYS.push :field
+SimpleEnum.register_generator :mongoid, SimpleEnum::Mongoid::Extension

--- a/spec/simple_enum/attribute_spec.rb
+++ b/spec/simple_enum/attribute_spec.rb
@@ -13,7 +13,7 @@ describe SimpleEnum::Attribute do
   context '.register_generator' do
     let(:mod) {
       Module.new do
-        def generate_enum_spec_extension_for(enum, accessor)
+        def generate_enum_spec_extension_for(enum, accessor, options)
           module_eval { attr_accessor :some_reader }
           simple_enum_module.module_eval do
             define_method("extension_method") { "as_enum(#{enum.name})" }

--- a/spec/simple_enum/mongoid_spec.rb
+++ b/spec/simple_enum/mongoid_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'simple_enum/mongoid'
+SimpleEnum::Attribute::EXTENSIONS.clear
 
 describe SimpleEnum::Mongoid, mongoid: true do
   fake_mongoid_model(:klass) {
@@ -7,6 +8,9 @@ describe SimpleEnum::Mongoid, mongoid: true do
   }
 
   let(:field) { klass.fields['gender_cd'] }
+
+  before { SimpleEnum.register_generator :mongoid, SimpleEnum::Mongoid::Extension }
+  after { SimpleEnum::Attribute::EXTENSIONS.clear }
 
   context '.as_enum' do
     subject { klass }


### PR DESCRIPTION
So extension can add an additional option to `as_enum`, by doing `SimpleEnum::Attribute::VALID_OPTION_KEYS.push :my_option`

Rewrite `SimpleEnum::Mongoid` as an example