### PR TITLE
Rewrite mongoid, use 'accessor.source'

### DIFF
--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -22,6 +22,7 @@ module SimpleEnum
       hash     = SimpleEnum::Hasher.map(values, options)
       enum     = SimpleEnum::Enum.new(name, hash)
       accessor = SimpleEnum::Accessors.accessor(name, enum, options)
+      enum.accessor = accessor
 
       generate_enum_class_accessors_for(enum, accessor)
       generate_enum_instance_accessors_for(enum, accessor)

--- a/lib/simple_enum/enum.rb
+++ b/lib/simple_enum/enum.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/string'
 module SimpleEnum
   class Enum
     attr_reader :name, :hash
+    attr_accessor :accessor
 
     def initialize(name, hash)
       @name = name.to_s

--- a/lib/simple_enum/mongoid.rb
+++ b/lib/simple_enum/mongoid.rb
@@ -33,14 +33,16 @@ module SimpleEnum
       # Wrap method chain to create mongoid field and additional
       # column options
       def as_enum(name, values, options = {})
-        source = options[:source].to_s.presence || "#{name}#{SimpleEnum.suffix}"
         field_options = options.delete(:field)
+        enum = super
+        accessor = send("#{name.to_s.pluralize}_accessor")
+
         unless field_options === false
           field_options ||= SimpleEnum.field
-          field(source, field_options) if field_options
+          field(accessor.source, field_options) if field_options
         end
 
-        super
+        enum
       end
     end
   end

--- a/lib/simple_enum/mongoid.rb
+++ b/lib/simple_enum/mongoid.rb
@@ -35,7 +35,7 @@ module SimpleEnum
       def as_enum(name, values, options = {})
         field_options = options.delete(:field)
         enum = super
-        accessor = send("#{name.to_s.pluralize}_accessor")
+        accessor = enum.accessor
 
         unless field_options === false
           field_options ||= SimpleEnum.field


### PR DESCRIPTION
I've found an issue during writing the code:
`genders_accessor` method only exists when `with.include? :class`, otherwise, it will raise a `NoMethodError`, it's kinda tricky.

So I add an `accessor` attribute to `enum`, but in fact, I don't like it either, because it's weird that we have `enum.accessor` and `accessor.enum`, and if we use `attr_accessor :accessor`, people can change `enum.accessor` by themselves, if not, aka: `attr_reader :accessor`, we have to use something like `instance_variable_set`.