### PR TITLE
Upgrade mongoid 6 and rails 5

### DIFF
--- a/lib/simple_enum/enum_hash.rb
+++ b/lib/simple_enum/enum_hash.rb
@@ -10,7 +10,7 @@ module SimpleEnum
     def self.symbolize(sym)
       return sym.to_enum_sym if sym.respond_to?(:to_enum_sym)
       return sym.to_sym if sym.respond_to?(:to_sym)
-      return sym.name.to_s.parameterize('_').to_sym if sym.respond_to?(:name)
+      return sym.name.to_s.parameterize(separator: '_').to_sym if sym.respond_to?(:name)
       sym.to_param.to_sym if sym.present? && sym.respond_to?(:to_param)
       sym unless sym.blank?
     end

--- a/lib/simple_enum/validation.rb
+++ b/lib/simple_enum/validation.rb
@@ -1,3 +1,5 @@
+require 'active_model'
+
 module ActiveModel
   module Validations
     class AsEnumValidator < ActiveModel::Validator
@@ -9,11 +11,8 @@ module ActiveModel
         super
       end
 
-      def setup(klass)
-        @klass = klass
-      end
-
       def validate(record)
+        @klass ||= record.class
         attributes.each do |attribute|
           enum_def = @klass.enum_definitions[attribute]
           raw_value = record.send(enum_def[:column])

--- a/simple_enum.gemspec
+++ b/simple_enum.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency "activesupport", '= 5.0.4'
+  s.add_dependency "activesupport", '>= 5'
 
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'minitest'
-  s.add_development_dependency 'activerecord', '>= 3.0.0'
-  s.add_development_dependency 'mongoid', '= 6.0.3'
+  s.add_development_dependency 'activerecord', '>= 5'
+  s.add_development_dependency 'mongoid', '>= 6'
 end

--- a/simple_enum.gemspec
+++ b/simple_enum.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary     = "Simple enum-like field support for models."
   s.description = "Provides enum-like fields for ActiveRecord, ActiveModel and Mongoid models."
 
-  s.required_ruby_version     = ">= 1.8.7"
+  s.required_ruby_version     = ">= 2.2.2"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.authors  = ["Lukas Westermann"]
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
 
   s.license          = 'MIT'
 
-  s.add_dependency "activesupport", '>= 3.0.0'
+  s.add_dependency "activesupport", '= 5.0.4'
 
   s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'minitest', '~> 2.0'
+  s.add_development_dependency 'minitest'
   s.add_development_dependency 'activerecord', '>= 3.0.0'
-  s.add_development_dependency 'mongoid', '~> 2.0'
+  s.add_development_dependency 'mongoid', '= 6.0.3'
 end

--- a/test/array_conversions_test.rb
+++ b/test/array_conversions_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ArrayConversionsTest < MiniTest::Unit::TestCase
+class ArrayConversionsTest < Minitest::Test
   def setup
     reload_db :genders => true
   end

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ClassMethodsTest < MiniTest::Unit::TestCase
+class ClassMethodsTest < Minitest::Test
   def setup
     reload_db
   end

--- a/test/class_methods_test.rb
+++ b/test/class_methods_test.rb
@@ -35,8 +35,6 @@ class ClassMethodsTest < Minitest::Test
   end
 
   def test_generation_of_value_shortcuts_on_class
-    g = Dummy.new
-
     assert_equal 0, Dummy.male
     assert_equal 1, Dummy.female
     assert_equal 'alpha', Dummy.alpha

--- a/test/enum_hash_test.rb
+++ b/test/enum_hash_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'simple_enum/enum_hash'
 
-class EnumHashTest < MiniTest::Unit::TestCase
+class EnumHashTest < Minitest::Test
 
   def test_create_new_enumhash_instance_from_array_of_symbols
     genders = SimpleEnum::EnumHash.new [:male, :female]

--- a/test/finders_test.rb
+++ b/test/finders_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FindersTest < MiniTest::Unit::TestCase
+class FindersTest < Minitest::Test
   def setup
     reload_db
   end

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -27,7 +27,7 @@ class MongoidTest < Minitest::Test
 
     gender_field = klass.new.fields['gender_cd']
     refute_nil gender_field
-    assert_equal 1, gender_field.default
+    assert_equal 1, gender_field.options[:default]
     assert_equal klass.fields['verify'].class, gender_field.class
     assert_equal :female, klass.new.gender
   end

--- a/test/mongoid_test.rb
+++ b/test/mongoid_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class MongoidTest < MiniTest::Unit::TestCase
+class MongoidTest < Minitest::Test
   def setup
     @default_options = SimpleEnum.default_options
     reload_db

--- a/test/object_backed_test.rb
+++ b/test/object_backed_test.rb
@@ -18,9 +18,10 @@ class ObjectBackedTest < Minitest::Test
     with_object = anonymous_dummy do
       as_enum :gender, { simple_obj.new('Male') => 0, simple_obj.new('Female') => 1 }      
     end
-        
-    d = with_object.where(:name => 'Anna').first
-    
+
+    d = with_object.where(:name => 'Anna')
+    d = d.where('_type' => nil) if mongoid?
+    d = d.first
     assert_same simple_obj, d.gender.class
     assert_equal 'Female', d.gender.name
     assert_same true, d.female?

--- a/test/object_backed_test.rb
+++ b/test/object_backed_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ObjectBackedTest < MiniTest::Unit::TestCase
+class ObjectBackedTest < Minitest::Test
   def setup
     reload_db :genders => true    
   end

--- a/test/object_backed_test.rb
+++ b/test/object_backed_test.rb
@@ -38,9 +38,9 @@ class ObjectBackedTest < Minitest::Test
     with_db_obj = anonymous_dummy do
       as_enum :gender, genders
     end
-    
-    d = with_db_obj.where(:name => 'Bella').first
-    
+
+    with_db_obj.where(:name => 'Bella').first
+
     assert_respond_to with_db_obj, :female
     assert_respond_to with_db_obj, :male
     assert_equal 0, with_db_obj.male

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -4,22 +4,11 @@ def orm_version
   ActiveRecord::VERSION::STRING
 end
 
-def ar32?
-  ActiveRecord::VERSION::MAJOR >= 3 && ActiveRecord::VERSION::MINOR >= 2
-end
-
 def setup_db
   # create database connection (in memory db!)
   ActiveRecord::Base.establish_connection({
     :adapter => RUBY_PLATFORM =~ /java/ ? 'jdbcsqlite3' : 'sqlite3',
     :database => ':memory:'})
-    
-  # Fix visitor, for JRuby
-  if RUBY_PLATFORM =~ /java/ && ar32?
-    ActiveRecord::ConnectionAdapters::SQLiteAdapter.send(:define_method, :visitor) do
-      @visitor ||= Arel::Visitors::SQLite.new(self)
-    end
-  end
 end
 
 # Reload database
@@ -52,15 +41,15 @@ end
 # Models
 def anonymous_dummy(&block)
   Class.new(ActiveRecord::Base) do
-    ar32? ? self.table_name = 'dummies' : set_table_name('dummies')
-    instance_eval &block 
+    self.table_name = 'dummies'
+    instance_eval(&block)
   end
 end
 
 def extend_computer(current_i18n_name = "Computer", &block)
   Class.new(Computer) do
-    ar32? ? self.table_name = 'computers' : set_table_name('computers')
-    instance_eval &block
+    self.table_name = 'computers'
+    instance_eval(&block)
     instance_eval <<-RUBY
       def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
     RUBY
@@ -69,8 +58,8 @@ end
 
 def extend_dummy(current_i18n_name = "Dummy", &block)
   Class.new(Dummy) do
-    ar32? ? self.table_name = 'dummies' : set_table_name('dummies')
-    instance_eval &block
+    self.table_name = 'dummies'
+    instance_eval(&block)
     instance_eval <<-RUBY
       def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
     RUBY
@@ -83,8 +72,8 @@ def named_dummy(class_name, &block)
   rescue NameError
     klass = Object.const_set(class_name, Class.new(ActiveRecord::Base))
     klass.module_eval do
-      ar32? ? self.table_name = 'dummies' : set_table_name('dummies')
-      instance_eval &block
+      self.table_name = 'dummies'
+      instance_eval(&block)
     end
     klass
   end
@@ -109,6 +98,6 @@ end
 
 # Used to test STI stuff
 class SpecificDummy < Dummy
-  ar32? ? self.table_name = 'dummies' : set_table_name('dummies')
+  self.table_name = 'dummies'
 end
 

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -20,8 +20,8 @@ end
 def reload_db(options = {})
 
   # clear collections except system
-  Mongoid.master.collections.select do |collection|
-    collection.name !~ /system/
+  Mongoid.default_client.collections.reject do |collection|
+    collection.name =~ /system/
   end.each(&:drop)
 
   fill_db(options)

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -32,15 +32,14 @@ def anonymous_dummy(&block)
   Class.new do
     include Mongoid::Document
     include SimpleEnum::Mongoid
-    self.collection_name = 'dummies'
-    instance_eval &block
+    store_in collection: 'dummies'
+    instance_eval(&block)
   end
 end
 
 def extend_computer(current_i18n_name = "Computer", &block)
   Class.new(Computer) do
-    self.collection_name = 'computers'
-    instance_eval &block
+    instance_eval(&block)
     instance_eval <<-RUBY
       def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
     RUBY
@@ -49,8 +48,7 @@ end
 
 def extend_dummy(current_i18n_name = "Dummy", &block)
   Class.new(Dummy) do
-    self.collection_name = 'dummies'
-    instance_eval &block
+    instance_eval(&block)
     instance_eval <<-RUBY
       def self.model_name; MockName.mock!(#{current_i18n_name.inspect}) end
     RUBY
@@ -66,8 +64,8 @@ def named_dummy(class_name, &block)
       include Mongoid::Document
       include SimpleEnum::Mongoid
 
-      self.collection_name = 'dummies'
-      instance_eval &block
+      store_in collection: 'dummies'
+      instance_eval(&block)
     end
 
     klass
@@ -78,6 +76,7 @@ end
 class Dummy
   include Mongoid::Document
   include SimpleEnum::Mongoid
+  store_in collection: 'dummies'
 
   as_enum :gender, [:male, :female]
   as_enum :word, { :alpha => 'alpha', :beta => 'beta', :gamma => 'gamma'}
@@ -104,6 +103,7 @@ end
 class Computer
   include Mongoid::Document
   include SimpleEnum::Mongoid
+  store_in collection: 'computers'
 
   field :name, :type => String
 

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -8,7 +8,8 @@ end
 def setup_db
   # create database connection
   Mongoid.configure do |config|
-    config.master = Mongo::Connection.new('localhost').db("simple-enum-test-suite")
+    config.load_configuration(clients: { default: { database: 'simple_enum_test_suite',
+                                                    hosts: ['localhost:27017'] } })
     config.use_utc = true
     config.include_root_in_json = true
   end

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -84,6 +84,7 @@ class Dummy
   as_enum :role, [:admin, :member, :anon], :strings => true
   as_enum :numeric, [:"100", :"3.14"], :strings => true
   as_enum :nilish, [:nil], :strings => true
+  field :name, :type => String
 
   before_save :check_typed
 

--- a/test/poro_test.rb
+++ b/test/poro_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class POROTest < MiniTest::Unit::TestCase
+class POROTest < Minitest::Test
   class MyPORO
     include SimpleEnum
 

--- a/test/prefixes_test.rb
+++ b/test/prefixes_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PrefixesTest < MiniTest::Unit::TestCase
+class PrefixesTest < Minitest::Test
   def setup
     reload_db
   end

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -286,7 +286,7 @@ class SimpleEnumTest < Minitest::Test
 
   def test_argument_error_is_raised_when_using_enum_name_eq_column_name
     begin
-      invalid_dummy = anonymous_dummy do
+      anonymous_dummy do
         as_enum :gender_cd, [:male, :female], :column => "gender_cd"
       end
       assert false, "no error raised"

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SimpleEnumTest < MiniTest::Unit::TestCase
+class SimpleEnumTest < Minitest::Test
   def setup
     reload_db
   end

--- a/test/simple_enum_test.rb
+++ b/test/simple_enum_test.rb
@@ -15,7 +15,7 @@ class SimpleEnumTest < Minitest::Test
   end
 
   def test_enum_definitions_local_to_model
-    assert_equal nil, Computer.enum_definitions[:gender]
+    assert_nil Computer.enum_definitions[:gender]
   end
 
   def test_getting_the_correct_integer_values_when_setting_to_symbol
@@ -57,8 +57,8 @@ class SimpleEnumTest < Minitest::Test
   def test_setting_value_to_nil_when_enum_has_nil_as_symbol_and_strings_is_true
     d = Dummy.new
     d.nilish = nil
-    assert_equal(nil, d.nilish)
-    assert_equal(nil, d.nilish_cd)
+    assert_nil(d.nilish)
+    assert_nil(d.nilish_cd)
   end
 
   def test_setting_value_as_key_in_constructor

--- a/test/without_shortcuts_test.rb
+++ b/test/without_shortcuts_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class WithoutShortcutsTest < MiniTest::Unit::TestCase  
+class WithoutShortcutsTest < Minitest::Test  
   def setup
     reload_db
     


### PR DESCRIPTION
Keep same api but make it compatible with rails 5.x and mongoid 6.x

- Basically I've just removed alias_method_chain
- Remove some deprecation warnings
