### PR TITLE
Add a pluralize_scopes option to control what scope methods are generated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.3.3
   - 2.4.0
   - ruby-head
-  - jruby-19mode
+  - jruby
 
 gemfile:
   - Gemfile
@@ -42,12 +42,16 @@ matrix:
       gemfile: gemfiles/mongoid-4.0.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/mongoid-5.0.gemfile
-    - rvm: jruby-19mode
-      gemfile: Gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails-5.1.gemfile
-    - rvm: jruby-19mode
-      gemfile: gemfiles/mongoid-6.0.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/rails-4.0.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/rails-4.1.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/rails-4.2.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/mongoid-4.0.gemfile
+    - rvm: jruby
+      gemfile: gemfiles/mongoid-5.0.gemfile
 
 addons:
   code_climate:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,36 @@ User.genders.values_at(:male, :female)  # => [0, 1] (since 2.1.0)
 User.females                            # => #<ActiveRecord::Relation:0x0.....> (WHERE gender_cd = 1)
 ```
 
+By default, scope names are generated as pluralized forms of the defined enum values e.g.
+
+```ruby
+class Booking < ActiveRecord::Base
+  as_enum :status, active: 1, cancelled: 2, pending: 3
+end
+```
+
+would generate the following:
+```ruby
+Booking.actives     # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 1)
+Booking.cancelleds  # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 2)
+Booking.pendings    # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 3)
+```
+
+By setting `pluralize_scopes: false` will not generate pluralized versions of scopes e.g.
+
+```ruby
+class Booking < ActiveRecord::Base
+  as_enum :status, active: 1, cancelled: 2, pending: 3, pluralize_scopes: false
+end
+```
+
+would generate the following:
+```ruby
+Booking.active     # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 1)
+Booking.cancelled  # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 2)
+Booking.pending    # => #<ActiveRecord::Relation:0x0.....> (WHERE status_cd = 3)
+```
+
 ### Wait, there's more!
 
 - Too tired of always adding the integer values? Try:
@@ -223,9 +253,9 @@ so expect them to change in future versions of SimpleEnum.
   translate_enum user, :gender # => "Frau" # assuming :de and translations exist
   te user, :gender # translate_enum is also aliased to te
   ```
-  
+
   Provide translations in the i18n yaml file like:
-  
+
   ```ruby
     de:
       enums:
@@ -233,13 +263,13 @@ so expect them to change in future versions of SimpleEnum.
           female: 'Frau'
           male: 'Mann'
   ```
-  
+
 - Build a select tag with a translated dropdown and symbol as value:
 
   ```ruby
   select :user, :gender, enum_option_pairs(User, :gender)
   ```
-  
+
 - ...and one with the index as value:
 
   ```ruby

--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -33,6 +33,9 @@ module SimpleEnum
   mattr_accessor :field
   @@field = {}
 
+  mattr_accessor :pluralize_scopes
+  @@pluralize_scopes = true
+
   def self.configure
     yield(self)
   end

--- a/spec/simple_enum/attribute_spec.rb
+++ b/spec/simple_enum/attribute_spec.rb
@@ -223,6 +223,38 @@ describe SimpleEnum::Attribute do
         subject { klass.gender_females }
         it_behaves_like 'delegates to accessor#scope', 1
       end
+
+      context 'and pluralize scopes option is set to false' do
+        fake_active_record(:klass) {
+          as_enum :gender, [:male, :female], with: [:scope], prefix: true, pluralize_scopes: false
+        }
+
+        context '.gender_male' do
+          subject { klass.gender_male }
+          it_behaves_like 'delegates to accessor#scope', 0
+        end
+
+        context '.gender_female' do
+          subject { klass.gender_female }
+          it_behaves_like 'delegates to accessor#scope', 1
+        end
+      end
+    end
+
+    context 'when pluralize scopes option is set to false' do
+      fake_active_record(:klass) {
+        as_enum :gender, [:male, :female], with: [:scope], pluralize_scopes: false
+      }
+
+      context '.male' do
+        subject { klass.male }
+        it_behaves_like 'delegates to accessor#scope', 0
+      end
+
+      context '.female' do
+        subject { klass.female }
+        it_behaves_like 'delegates to accessor#scope', 1
+      end
     end
 
     context 'without scope method' do


### PR DESCRIPTION
In an attempt to resolve https://github.com/lwe/simple_enum/issues/120 this PR adds another option, namely `pluralize_scopes`, to solve this.

Instead of modifying the structure / names of the existing options this new option will make a new release backwards compatible.