### PR TITLE
Fix regression when classes are not cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ By default, scope names are generated as pluralized forms of the defined enum va
 
 ```ruby
 class Booking < ActiveRecord::Base
-  as_enum :status, active: 1, cancelled: 2, pending: 3
+  as_enum :status, %i{active cancelled pending}
 end
 ```
 
@@ -121,7 +121,7 @@ By setting `pluralize_scopes: false` will not generate pluralized versions of sc
 
 ```ruby
 class Booking < ActiveRecord::Base
-  as_enum :status, active: 1, cancelled: 2, pending: 3, pluralize_scopes: false
+  as_enum :status, %i{active cancelled pending}, pluralize_scopes: false
 end
 ```
 

--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -56,13 +56,13 @@ module SimpleEnum
 
     def generate_additional_enum_methods_for(enum, accessor, options)
       with_options = Array.wrap(options.fetch(:with, SimpleEnum.with))
-      scope_option = with_options.delete(:scope)
+      scope_option, feature_options = with_options.partition { |option| option == :scope }
 
-      with_options.each do |feature|
+      feature_options.each do |feature|
         send "generate_enum_#{feature}_methods_for", enum, accessor
       end
 
-      if scope_option
+      unless scope_option.empty?
         pluralize_scopes = options.fetch(:pluralize_scopes, SimpleEnum.pluralize_scopes)
         generate_enum_scope_methods_for(enum, accessor, pluralize_scopes)
       end


### PR DESCRIPTION
The default config for development in Rails apps is `config.cache_classes = false` so https://github.com/lwe/simple_enum/pull/135 caused a regression as the scope option had already been deleted from the `with` options array when the app reloads after any change so the scope methods would not be made.

Also, updated the Readme as options do not work when the enum values are defined as a hash