### PR TITLE
Fix scoping issue for recent AR / Mongoid versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ gemfile:
   - gemfiles/rails-4.1.gemfile
   - gemfiles/rails-4.2.gemfile
   - gemfiles/rails-5.1.gemfile
+  - gemfiles/rails-5.2.gemfile
   - gemfiles/mongoid-4.0.gemfile
   - gemfiles/mongoid-5.0.gemfile
   - gemfiles/mongoid-6.0.gemfile
+  - gemfiles/mongoid-7.0.gemfile
 
 matrix:
   exclude:
@@ -25,7 +27,11 @@ matrix:
     - rvm: 1.9.3
       gemfile: gemfiles/rails-5.1.gemfile
     - rvm: 1.9.3
+      gemfile: gemfiles/rails-5.2.gemfile
+    - rvm: 1.9.3
       gemfile: gemfiles/mongoid-6.0.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/mongoid-7.0.gemfile
     - rvm: 2.4.0
       gemfile: gemfiles/rails-4.0.gemfile
     - rvm: 2.4.0

--- a/gemfiles/mongoid-7.0.gemfile
+++ b/gemfiles/mongoid-7.0.gemfile
@@ -1,7 +1,6 @@
 source "http://rubygems.org"
 
-gem 'activesupport', '~> 5.1.0'
-gem 'activerecord', '~> 5.1.0'
+gem 'mongoid', '~> 7.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby

--- a/gemfiles/rails-5.2.gemfile
+++ b/gemfiles/rails-5.2.gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
-gem 'activesupport', '~> 5.1.0'
-gem 'activerecord', '~> 5.1.0'
+gem 'activesupport', '~> 5.2.0'
+gem 'activerecord', '~> 5.2.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby

--- a/lib/simple_enum/attribute.rb
+++ b/lib/simple_enum/attribute.rb
@@ -87,9 +87,11 @@ module SimpleEnum
     def generate_enum_scope_methods_for(enum, accessor, pluralize_scopes)
       return unless respond_to?(:scope)
 
+      klass = self
+
       enum.each_pair do |key, value|
         scope_key = pluralize_scopes ? key.pluralize : key
-        scope "#{accessor.prefix}#{scope_key}", -> { accessor.scope(self, value) }
+        scope "#{accessor.prefix}#{scope_key}", -> { accessor.scope(klass, value) }
       end
     end
   end

--- a/simple_enum.gemspec
+++ b/simple_enum.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 4.0.0'
 
-  s.add_development_dependency 'rake', '>= 10.1.0'
+  s.add_development_dependency 'rake', '>= 10.1.0', '< 12.3.0'
   s.add_development_dependency 'activerecord', '>= 4.0.0'
   s.add_development_dependency 'mongoid', '>= 4.0.0'
   s.add_development_dependency 'rspec', '~> 2.14'


### PR DESCRIPTION
This https://github.com/rails/rails/commit/4bdd86fb1e608d0031ee5e03af4ae0b13b41fea3 changed what `self` was inside a scope proc (assume something similar in mongoid as well), pulled the class out to make this work in new versions and still backwards compatible.

Added CI tests for newest versions of Rails and Mongoid as well.