### PR TITLE
Downgrade sqlite3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only

--- a/gemfiles/mongoid-4.0.gemfile
+++ b/gemfiles/mongoid-4.0.gemfile
@@ -4,7 +4,7 @@ gem 'mongoid', '~> 4.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only

--- a/gemfiles/mongoid-5.0.gemfile
+++ b/gemfiles/mongoid-5.0.gemfile
@@ -4,7 +4,7 @@ gem 'mongoid', '~> 5.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only

--- a/gemfiles/rails-4.0.gemfile
+++ b/gemfiles/rails-4.0.gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', '~> 4.0.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only

--- a/gemfiles/rails-4.1.gemfile
+++ b/gemfiles/rails-4.1.gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', '~> 4.1.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only

--- a/gemfiles/rails-4.2.gemfile
+++ b/gemfiles/rails-4.2.gemfile
@@ -5,7 +5,7 @@ gem 'activerecord', '~> 4.2.0'
 
 # some development deps
 gem 'activerecord-jdbcsqlite3-adapter', platform: :jruby
-gem 'sqlite3', platform: :ruby
+gem 'sqlite3', '~> 1.3.6', platform: :ruby
 gem 'bson_ext', platform: :ruby
 
 # Code coverage on CI only


### PR DESCRIPTION
## Why
- sqlite3_adapter has conflict with version of sqlite3 gem in Rails 5.0.x and older.
https://github.com/rails/rails/issues/35153

## What
- Downgrade sqlite3 from 1.4.1 to 1.3.6