### PR TITLE
Allow empty Strings when using `whiny` Accessor.

### DIFF
--- a/lib/simple_enum/accessors/whiny_accessor.rb
+++ b/lib/simple_enum/accessors/whiny_accessor.rb
@@ -4,7 +4,7 @@ module SimpleEnum
   module Accessors
     class WhinyAccessor < Accessor
       def write(object, key)
-        raise ArgumentError, "#{key} is not a valid enum value for #{enum}" if key && !enum.include?(key)
+        raise ArgumentError, "#{key} is not a valid enum value for #{enum}" if key.present? && !enum.include?(key)
         super
       end
     end


### PR DESCRIPTION
When setting `accessor: :whiny`, you are permitted to pass in a key value of `nil` but not an empty String `""`. 

```ruby
to_do.state = nil
#=> nil

to_do.state = ""
#=> ArgumentError ( is not a valid enum value for state)
```

This can cause issues, especially on forms with `select` elements. For example, by default a blank `option` with a value set to `nil` comes through as a param value of an empty String. Setting the enum attribute with an empty String throws an error.

Even normalizing your data with gems like `strip_attributes` that strip leading/trailing whitespace and converts empty Strings into `nil` does not fix the issue because that occurs before validation, after simple_enum applies the attribute's value and throws the error.

This commit checks that the key is present, not just a non-`nil` value, and allows for empty Strings not to raise an error.

```bash
> key = ""
=> ""
> puts 'hi' if key
hi
=> nil
> puts 'hi' if key.present?
=> nil
```