### PR TITLE
Use double-splat for Ruby 3.0 compatibility

### DIFF
--- a/lib/simple_enum.rb
+++ b/lib/simple_enum.rb
@@ -12,7 +12,11 @@ require 'active_support'
 
 require 'simple_enum/version'
 require 'simple_enum/attribute'
-require 'simple_enum/translation'
+begin
+  require 'simple_enum/translation'
+rescue SyntaxError
+  require 'simple_enum/translation_ruby19'
+end
 require 'simple_enum/view_helpers'
 
 # Base module which gets included in <tt>ActiveRecord::Base</tt>. See documentation

--- a/lib/simple_enum/translation_ruby19.rb
+++ b/lib/simple_enum/translation_ruby19.rb
@@ -15,7 +15,7 @@ module SimpleEnum
       defaults << key.to_s.humanize
 
       options.reverse_merge! count: 1, default: defaults
-      I18n.translate(defaults.shift, **options)
+      I18n.translate(defaults.shift, options)
     end
   end
 end


### PR DESCRIPTION
Ruby 3.0 separates keyword arguments from positional arguments. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This PR makes `simple_enum` compatible with the new behavior. As `**` isn't supported in Ruby 1.9, this PR falls back to the old source code without `**` when a syntax error occurs.